### PR TITLE
Fixed install for Widevine component.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,41 +49,33 @@ RUN apt-get update && apt-get -y dist-upgrade && \
         libappindicator3-1 \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mkdir -p /var/run/dbus \
-    && mkdir -p /etc/chromium/policies/managed /etc/chromium/policies/recommended \
+    && mkdir -p /etc/chromium/policies/managed \
+    && mkdir -p /etc/opt/chrome/policies/managed \
     && mkdir /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix && chown root /tmp/.X11-unix
-    
+
 # Install Widevine component for Chromium
-RUN WIDEVINE_VERSION=$(wget --quiet -O - https://dl.google.com/widevine-cdm/versions.txt | tail -n 1) && \
-    wget "https://dl.google.com/widevine-cdm/$WIDEVINE_VERSION-linux-x64.zip" -O /tmp/widevine.zip && \
-    mkdir /usr/lib/chromium/WidevineCdm && \
-    mkdir /usr/lib/chromium/WidevineCdm/_platform_specific && \
-    mkdir /usr/lib/chromium/WidevineCdm/_platform_specific/linux_x64 && \
-    unzip -p /tmp/widevine.zip manifest.json > /usr/lib/chromium/WidevineCdm/manifest.json && \
-    unzip -p /tmp/widevine.zip LICENSE.txt > /usr/lib/chromium/WidevineCdm/LICENSE.txt && \
-    unzip -p /tmp/widevine.zip libwidevinecdm.so > /usr/lib/chromium/WidevineCdm/_platform_specific/linux_x64/libwidevinecdm.so && \
-    rm /tmp/widevine.zip
+RUN WIDEVINE_VERSION=$(wget --quiet -O - https://dl.google.com/widevine-cdm/versions.txt | tail -n 1) \
+    && wget "https://dl.google.com/widevine-cdm/$WIDEVINE_VERSION-linux-x64.zip" -O /tmp/widevine.zip \
+    && unzip /tmp/widevine.zip -d /usr/lib/chromium/WidevineCdm \
+    && rm /tmp/widevine.zip
 
 # Add normal user
 RUN useradd glados --shell /bin/bash --create-home \
     && usermod -a -G audio glados \ 
-    && mkdir /etc/opt/chrome/ \
-    && mkdir /etc/opt/chrome/policies \
-    && mkdir /etc/opt/chrome/policies/managed \
-    && mkdir /home/glados/.config \
-    && mkdir /home/glados/.config/google-chrome/ \
-    && chown glados /home/glados/.config/ \
-    && chown glados /home/glados/.config/google-chrome/ \
+    && mkdir -r /home/glados/.config/google-chrome \
+    && chown -R glados:glados /home/glados/.config/google-chrome \
     && touch "/home/glados/.config/google-chrome/First Run"
 
 # Copy information
 WORKDIR /home/glados/.internal
 COPY . .
 
-# Chromium Policies
+# Chromium Policies and Preferences
 COPY ./configs/chromium_policy.json /etc/chromium/policies/managed/policies.json
-# Chromium Preferences
 COPY ./configs/master_preferences.json /etc/chromium/master_preferences
-COPY ./configs/managed_policies.json /etc/opt/chrome/policies/managed/managed_policies.json
+# Chrome Policies and Preferences
+COPY ./configs/managed_policies.json /etc/opt/chrome/policies/managed/policies.json
+COPY ./configs/master_preferences.json /etc/opt/chrome/master_preferences
 # Pulseaudio Configuration
 COPY ./configs/pulse_config.pa /tmp/pulse_config.pa
 # Openbox Configuration

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,6 @@ RUN apt-get update && apt-get -y dist-upgrade && \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mkdir -p /var/run/dbus \
     && mkdir -p /etc/chromium/policies/managed \
-    && mkdir -p /etc/opt/chrome/policies/managed \
     && mkdir /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix && chown root /tmp/.X11-unix
 
 # Install Widevine component for Chromium
@@ -61,10 +60,7 @@ RUN WIDEVINE_VERSION=$(wget --quiet -O - https://dl.google.com/widevine-cdm/vers
 
 # Add normal user
 RUN useradd glados --shell /bin/bash --create-home \
-    && usermod -a -G audio glados \ 
-    && mkdir -p /home/glados/.config/google-chrome \
-    && chown -R glados:glados /home/glados/.config/google-chrome \
-    && touch "/home/glados/.config/google-chrome/First Run"
+    && usermod -a -G audio glados
 
 # Copy information
 WORKDIR /home/glados/.internal
@@ -73,9 +69,6 @@ COPY . .
 # Chromium Policies and Preferences
 COPY ./configs/chromium_policy.json /etc/chromium/policies/managed/policies.json
 COPY ./configs/master_preferences.json /etc/chromium/master_preferences
-# Chrome Policies and Preferences
-COPY ./configs/managed_policies.json /etc/opt/chrome/policies/managed/policies.json
-COPY ./configs/master_preferences.json /etc/opt/chrome/master_preferences
 # Pulseaudio Configuration
 COPY ./configs/pulse_config.pa /tmp/pulse_config.pa
 # Openbox Configuration

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,12 +55,13 @@ RUN apt-get update && apt-get -y dist-upgrade && \
 # Install Widevine component for Chromium
 RUN WIDEVINE_VERSION=$(wget --quiet -O - https://dl.google.com/widevine-cdm/versions.txt | tail -n 1) && \
     wget "https://dl.google.com/widevine-cdm/$WIDEVINE_VERSION-linux-x64.zip" -O /tmp/widevine.zip && \
-    unzip -p /tmp/widevine.zip libwidevinecdm.so > /usr/lib/chromium/libwidevinecdm.so && \
-    chmod 644 /usr/lib/chromium/libwidevinecdm.so && \
+    mkdir /usr/lib/chromium/WidevineCdm && \
+    mkdir /usr/lib/chromium/WidevineCdm/_platform_specific && \
+    mkdir /usr/lib/chromium/WidevineCdm/_platform_specific/linux_x64 && \
+    unzip -p /tmp/widevine.zip manifest.json > /usr/lib/chromium/WidevineCdm/manifest.json && \
+    unzip -p /tmp/widevine.zip LICENSE.txt > /usr/lib/chromium/WidevineCdm/LICENSE.txt && \
+    unzip -p /tmp/widevine.zip libwidevinecdm.so > /usr/lib/chromium/WidevineCdm/_platform_specific/linux_x64/libwidevinecdm.so && \
     rm /tmp/widevine.zip
-
-#RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
-#    sudo dpkg -i google-chrome-stable_current_amd64.deb
 
 # Add normal user
 RUN useradd glados --shell /bin/bash --create-home \

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,13 +49,17 @@ RUN apt-get update && apt-get -y dist-upgrade && \
         libappindicator3-1 \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mkdir -p /var/run/dbus \
-    && mkdir -p /etc/chromium/policies/managed \
+    && mkdir -p /etc/chromium/policies/managed /etc/chromium/policies/recommended \
     && mkdir /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix && chown root /tmp/.X11-unix
-
+    
 # Install Widevine component for Chromium
 RUN WIDEVINE_VERSION=$(wget --quiet -O - https://dl.google.com/widevine-cdm/versions.txt | tail -n 1) \
     && wget "https://dl.google.com/widevine-cdm/$WIDEVINE_VERSION-linux-x64.zip" -O /tmp/widevine.zip \
-    && unzip /tmp/widevine.zip -d /usr/lib/chromium/WidevineCdm \
+    && mkdir -p /tmp/WidevineCdm/_platform_specific/linux_x64 \
+    && unzip -p /tmp/widevine.zip manifest.json > /tmp/WidevineCdm/manifest.json \
+    && unzip -p /tmp/widevine.zip LICENSE.txt > /tmp/WidevineCdm/LICENSE.txt \
+    && unzip -p /tmp/widevine.zip libwidevinecdm.so > /tmp/WidevineCdm/_platform_specific/linux_x64/libwidevinecdm.so \
+    && mv /tmp/WidevineCdm /usr/lib/chromium/WidevineCdm \
     && rm /tmp/widevine.zip
 
 # Add normal user
@@ -66,7 +70,7 @@ RUN useradd glados --shell /bin/bash --create-home \
 WORKDIR /home/glados/.internal
 COPY . .
 
-# Chromium Policies and Preferences
+# Chromium Policies & Preferences
 COPY ./configs/chromium_policy.json /etc/chromium/policies/managed/policies.json
 COPY ./configs/master_preferences.json /etc/chromium/master_preferences
 # Pulseaudio Configuration

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN WIDEVINE_VERSION=$(wget --quiet -O - https://dl.google.com/widevine-cdm/vers
 # Add normal user
 RUN useradd glados --shell /bin/bash --create-home \
     && usermod -a -G audio glados \ 
-    && mkdir -r /home/glados/.config/google-chrome \
+    && mkdir -p /home/glados/.config/google-chrome \
     && chown -R glados:glados /home/glados/.config/google-chrome \
     && touch "/home/glados/.config/google-chrome/First Run"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,10 @@ RUN apt-get update && apt-get -y dist-upgrade && \
 # Install Widevine component for Chromium
 RUN WIDEVINE_VERSION=$(wget --quiet -O - https://dl.google.com/widevine-cdm/versions.txt | tail -n 1) \
     && wget "https://dl.google.com/widevine-cdm/$WIDEVINE_VERSION-linux-x64.zip" -O /tmp/widevine.zip \
-    && unzip /tmp/widevine.zip -d /usr/lib/chromium/WidevineCdm \
+    && unzip /tmp/widevine.zip -d /tmp/WidevineCdm \
+    && mkdir -p /tmp/WidevineCdm/_platform_specific/linux_x64 \
+    && mv /tmp/WidevineCdm/libwidevinecdm.so /tmp/WidevineCdm/_platform_specific/linux_x64/libwidevinecdm.so \
+    && mv /tmp/WidevineCdm /usr/lib/chromium/WidevineCdm \
     && rm /tmp/widevine.zip
 
 # Add normal user


### PR DESCRIPTION
Modified the way Widevine is installed. Chromium is looking for the component under a specific path. Mimicking the path found in Google Chrome resolves the issue.